### PR TITLE
Can add bool-values to database, can be tested with MyTestType

### DIFF
--- a/services/structured_mysql/batch_job_aurora/data_types/AbstractType.py
+++ b/services/structured_mysql/batch_job_aurora/data_types/AbstractType.py
@@ -86,6 +86,8 @@ class AbstractType:
                 columns_and_types += attr_name + " INT,\n"
             elif attr_type == float:
                 columns_and_types += attr_name + " DECIMAL(20,2),\n"
+            elif attr_type == bool:
+                columns_and_types += attr_name + " BOOL,\n"
             else:
                 print("Unsupported type.")
 

--- a/services/structured_mysql/batch_job_aurora/data_types/MyTestType.py
+++ b/services/structured_mysql/batch_job_aurora/data_types/MyTestType.py
@@ -1,0 +1,23 @@
+from data_types.AbstractType import AbstractType
+
+
+''' 
+This file is used for testing different attribute types in ingest
+
+Example data:
+{
+    "data":{
+            "testString":"StringHere",
+            "testInt":237,
+            "testBool":true
+            }
+}
+'''
+
+
+class MyTestType(AbstractType):
+    attributes_keep = {
+        ("testString", str): ["data", "testString"],
+        ("testInt", int): ["data", "testInt"],
+        ("testBool", bool): ["data", "testBool"]
+    }


### PR DESCRIPTION
Test by sending data to DynamoDB with the Ingest-service containing a bool-value.

curl -X POST -H 'x-api-key : API_KEY_GOES_HERE' -d '{"testString":"STRING HERE", "testInt":INT_HERE, "testBool":BOOL_HERE}' INGEST_LINK_HERE

Then run batch_job_aurora with:

sls invoke -f batch_job_mysql -d '{"types":["MyTestType"]}'

Then query Aurora for MyTestType. It might take some time before batch_job_mysql finds the data so wait for 5-10 minutes and try running batch_job_mysql again.