### PR TITLE
Feature/limit moto and s3fs versions

### DIFF
--- a/packages/common/setup.py
+++ b/packages/common/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup, find_namespace_packages
 setup(
     name='dataplattform_common',
     packages=find_namespace_packages(include=['dataplattform.*']),
-    install_requires=['dataclasses-json', 'boto3', 's3fs', 'fastparquet', 'pandas'],
+    install_requires=['dataclasses-json', 'boto3', 's3fs<0.5', 'fastparquet', 'pandas'],
     zip_safe=False)

--- a/packages/testing/setup.py
+++ b/packages/testing/setup.py
@@ -4,5 +4,6 @@ setup(
     name='dataplattform_testing',
     packages=find_namespace_packages(include=['dataplattform.*']),
     entry_points={"pytest11": ["dataplattform = dataplattform.testing.plugin"]},
-    install_requires=['pytest', 'pytest-env', 'pytest-mock', 'moto', 'dataclasses-json', 'boto3', 'pyathena'],
+    install_requires=['pytest', 'pytest-env', 'pytest-mock', 'moto<1.3.15',
+                      'dataclasses-json', 'boto3', 'botocore', 'pyathena'],
     zip_safe=False)


### PR DESCRIPTION
need to limit moto version and s3fs (with aiobotocore) to avoid a regression error breaking tests