### PR TITLE
Feature/320 delete report cache

### DIFF
--- a/packages/testing/dataplattform/testing/plugin.py
+++ b/packages/testing/dataplattform/testing/plugin.py
@@ -98,6 +98,8 @@ def sns_topic():
         sns = resource('sns')
         topic = sns.create_topic(Name=environ.get('SNS_TOPIC_NAME'))
         environ['DATA_UPDATE_TOPIC'] = topic.arn
+        environ['NEW_REPORT_TOPIC'] = topic.arn
+        environ['DELETE_REPORT_TOPIC'] = topic.arn
         yield topic
 
 

--- a/services/api/dataApi/apis/report.py
+++ b/services/api/dataApi/apis/report.py
@@ -45,4 +45,7 @@ class ReportItem(Resource):
     @ns.response(204, 'Report deleted')
     @ns.doc(security={'oauth2': ['openid']})
     def delete(self, name):
-        return report_service.delete_report(name), 204
+        try:
+            return report_service.delete_report(name), 204
+        except KeyError:
+            return f'Could not find ${name}', 404

--- a/services/api/dataApi/apis/report.py
+++ b/services/api/dataApi/apis/report.py
@@ -45,6 +45,4 @@ class ReportItem(Resource):
     @ns.response(204, 'Report deleted')
     @ns.doc(security={'oauth2': ['openid']})
     def delete(self, name):
-        with ReportsRepository() as repo:
-            repo.delete(name)
-            return '', 204
+        return report_service.delete_report(name), 204

--- a/services/api/dataApi/common_lib/common/services/cache_table_service.py
+++ b/services/api/dataApi/common_lib/common/services/cache_table_service.py
@@ -46,6 +46,11 @@ def query_cache_table(protection: int, name: str):
     return query
 
 
+def delete_cache_table(protection: int, name: str):
+    cached_object(protection, name).delete()
+    return True
+
+
 def cache_table(protection: int, name: str):
     cache_object = cached_object(protection, name)
 

--- a/services/api/dataApi/common_lib/common/services/report_service.py
+++ b/services/api/dataApi/common_lib/common/services/report_service.py
@@ -51,5 +51,5 @@ def delete_report(name: str):
     with ReportsRepository() as repo:
         report = repo.get(name)
         repo.delete(report['name'])
-        pub_delete_report(report['name'], report['dataProtection'])
+        pub_delete_report(report['name'], int(report['dataProtection']))
     return f"Deleted ${name}"

--- a/services/api/dataApi/common_lib/common/services/report_service.py
+++ b/services/api/dataApi/common_lib/common/services/report_service.py
@@ -37,3 +37,19 @@ def new_report(new_report: Dict[str, str]):
         })
         pub_new_report(new_report['name'])
         return repo.get(new_report['name'])
+
+
+def pub_delete_report(name: str, protection: int):
+    sns = boto3.resource('sns')
+    topic = sns.Topic(environ.get('DELETE_REPORT_TOPIC'))
+    topic.publish(
+        Message=json.dumps({'name': name, 'dataProtection': protection}),
+        Subject='DeleteReport')
+
+
+def delete_report(name: str):
+    with ReportsRepository() as repo:
+        report = repo.get(name)
+        repo.delete(report['name'])
+        pub_delete_report(report['name'], report['dataProtection'])
+    return f"Deleted ${name}"

--- a/services/api/dataApi/functions/cache_deleter.py
+++ b/services/api/dataApi/functions/cache_deleter.py
@@ -1,0 +1,22 @@
+import json
+from common.services.cache_table_service import delete_cache_table
+
+
+def handler(event, context):
+    records = event['Records']
+
+    def load_message(record):
+        rec = record.get('Sns')
+        return (rec.get('Subject', None), rec.get('Message', None))
+
+    messages = [(topic, json.loads(msg)) for topic, msg in [
+        load_message(record) for record in records
+    ] if topic]
+
+    for topic, message in messages:
+        if topic == 'DeleteReport':
+            delete_cache_table(
+                message['dataProtection'],
+                message['name'])
+
+    return {}

--- a/services/api/dataApi/requirements-test.txt
+++ b/services/api/dataApi/requirements-test.txt
@@ -1,1 +1,2 @@
+pyarrow
 file:../../../packages/testing

--- a/services/api/dataApi/serverless.yml
+++ b/services/api/dataApi/serverless.yml
@@ -121,6 +121,26 @@ functions:
           arn: !ImportValue ${self:custom.stage}-data-update-topic-arn
           topicName: ${self:custom.stage}-DataUpdate
 
+  CacheDeleter:
+    handler: cache_deleter.handler
+    module: functions
+    name: ${self:custom.service}-CacheDeleter
+    description: Dataplattform API Cache deleter
+    role:  !GetAtt CacheUpdaterRole.Arn
+    package:
+      include:
+        - 'functions/cache_deleter.py'
+    # destinations: # TODO
+    #   onSuccess: xxx:xxx:target
+    #   onFailure: xxx:xxx:target
+    environment:
+      DATALAKE: !ImportValue ${self:custom.stage}-datalakeName
+      STAGE: ${self:custom.stage}
+    events:
+      - sns:
+          arn: !ImportValue ${self:custom.stage}-delete-report-topic-arn
+          topicName: ${self:custom.stage}-DeleteReport
+
 resources:
   Resources:
     Authorizer:

--- a/services/api/dataApi/serverless.yml
+++ b/services/api/dataApi/serverless.yml
@@ -72,6 +72,7 @@ functions:
       DATALAKE: !ImportValue ${self:custom.stage}-datalakeName
       STAGE: ${self:custom.stage}
       NEW_REPORT_TOPIC: !ImportValue ${self:custom.stage}-new-report-topic-arn
+      DELETE_REPORT_TOPIC: !ImportValue ${self:custom.stage}-delete-report-topic-arn
     events:
       - http:
           method: ANY

--- a/services/api/dataApi/serverless.yml
+++ b/services/api/dataApi/serverless.yml
@@ -103,7 +103,7 @@ functions:
       - !ImportValue ${self:custom.stage}-fastparquetDepLayer-arn
     name: ${self:custom.service}-CacheUpdater
     description: Dataplattform API Cache updater
-    role:  !GetAtt CacheUpdaterRole.Arn
+    role:  !GetAtt ReportCacheRole.Arn
     package:
       include:
         - 'functions/cache_updater.py'
@@ -126,7 +126,7 @@ functions:
     module: functions
     name: ${self:custom.service}-CacheDeleter
     description: Dataplattform API Cache deleter
-    role:  !GetAtt CacheUpdaterRole.Arn
+    role:  !GetAtt ReportCacheRole.Arn
     package:
       include:
         - 'functions/cache_deleter.py'
@@ -167,10 +167,10 @@ resources:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
 
-    CacheUpdaterRole:
+    ReportCacheRole:
       Type: AWS::IAM::Role
       Properties:
-        RoleName: ${self:custom.service}-CacheUpdater-role
+        RoleName: ${self:custom.service}-ReportCache-role
         AssumeRolePolicyDocument:
           Version: "2012-10-17"
           Statement:
@@ -182,7 +182,7 @@ resources:
         ManagedPolicyArns:
           - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         Policies:
-          - PolicyName: ${self:custom.service}-CacheUpdater-policy
+          - PolicyName: ${self:custom.service}-ReportCache-policy
             PolicyDocument:
               Version: "2012-10-17"
               Statement:
@@ -207,6 +207,7 @@ resources:
                 - Effect: Allow
                   Action:
                     - s3:PutObject
+                    - s3:DeleteObject
                   Resource:
                     - Fn::Join:
                       - ""

--- a/services/api/dataApi/tests/test_cache_deleter.py
+++ b/services/api/dataApi/tests/test_cache_deleter.py
@@ -1,0 +1,54 @@
+import json
+from io import BytesIO
+
+import pytest
+import pandas as pd
+from functions.cache_deleter import handler
+
+
+cache_path = "reports/level-3/testReport.gzip"
+
+
+@pytest.fixture
+def mock_report_cache():
+    dataframe = pd.DataFrame({'a': [1, 1, 1], 'b': [1, 2, 3]})
+
+    file = BytesIO()
+
+    dataframe.to_parquet(
+        file,
+        compression='GZIP',
+        index=False
+    )
+    yield file
+
+
+@pytest.fixture
+def s3_with_report(s3_bucket, mock_report_cache):
+    s3_bucket.put_object(
+        Key=cache_path,
+        Body=mock_report_cache)
+    yield s3_bucket
+
+
+@pytest.fixture
+def sns_message():
+    yield {
+        'Records': [
+            {
+                'Sns': {
+                    'Subject': 'DeleteReport',
+                    'Message': json.dumps({
+                        'name': 'testReport',
+                        'dataProtection': 3
+                    })
+                }
+            }
+        ]
+    }
+
+
+def test_delete(s3_with_report, sns_message):
+    handler(sns_message, None)
+    all_objects = s3_with_report.objects.all()
+    assert all([obj.key != cache_path for obj in all_objects])

--- a/services/api/dataApi/tests/test_reports.py
+++ b/services/api/dataApi/tests/test_reports.py
@@ -1,6 +1,5 @@
 import pytest
 import app
-from moto import mock_sqs
 import json
 
 

--- a/services/api/dataApi/tests/test_reports_repository.py
+++ b/services/api/dataApi/tests/test_reports_repository.py
@@ -1,0 +1,81 @@
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from common.repositories.reports import ReportsRepository
+
+
+def test_get(dynamo_mock):
+    with ReportsRepository() as repo:
+        get_result = repo.get("testReport")
+    assert get_result['name'] == 'testReport'
+    assert get_result['dataProtection'] == 3
+    assert get_result['queryString'] == "COUNT(*) from dev_level_3_database.cv_partner_employees"
+
+
+def test_get_by_one_table(dynamo_mock):
+    with ReportsRepository() as repo:
+        get_by_tables_result = repo.get_by_tables(["test_table1"])
+    assert len(get_by_tables_result) == 1
+    assert get_by_tables_result[0]["name"] == "testReport"
+
+
+def test_get_by_many_tables(dynamo_mock):
+    with ReportsRepository() as repo:
+        get_by_tables_result = repo.get_by_tables(["test_table1", "test_table2"])
+    assert len(get_by_tables_result) == 1
+    assert get_by_tables_result[0]["name"] == "testReport"
+
+
+def test_all(dynamo_mock):
+    with ReportsRepository() as repo:
+        all_result = repo.all()
+    assert len(all_result) == 2
+    assert all_result[0]["name"] == "testReport"
+    assert all_result[1]["name"] == "anotherReport"
+
+
+def test_create(dynamo_mock):
+    additional_report = {
+        "dataProtection": 3,
+        "name": "new_report",
+        "queryString": "COUNT(*) from dev_level_3_database.cv_partner_employees",
+        "tables": [
+            "test_table5",
+            "test_table6"
+        ],
+        "lastUsed": "fail",
+        "lastCacheUpdate": "fail"
+    }
+    with ReportsRepository() as repo:
+        repo.create(additional_report)
+    new_item_result = dynamo_mock.get_item(Key={"name": "new_report"})
+    assert new_item_result['Item']['name'] == "new_report"
+    assert new_item_result['Item']['created'] is not None
+
+
+def test_update_cache_time(dynamo_mock):
+    with patch("common.repositories.reports.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2020, 1, 1)
+        mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        with ReportsRepository() as repo:
+            repo.update_cache_time("testReport")
+        new_item_result = dynamo_mock.get_item(Key={"name": "testReport"})
+        assert new_item_result['Item']['lastCacheUpdate'] == datetime(2020, 1, 1).isoformat()
+
+
+def test_update_cache_time_non_existing(dynamo_mock):
+    with patch("common.repositories.reports.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2020, 1, 1)
+        mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        with ReportsRepository() as repo:
+            with pytest.raises(KeyError):
+                repo.update_cache_time("testReport_non_existing")
+
+
+def test_delete(dynamo_mock):
+    with ReportsRepository() as repo:
+        repo.delete("testReport")
+    all_reports = dynamo_mock.scan()
+    assert len(all_reports['Items']) == 1
+    assert all_reports['Items'][0]['name'] == "anotherReport"

--- a/services/infrastructure/events/serverless.yml
+++ b/services/infrastructure/events/serverless.yml
@@ -22,6 +22,12 @@ resources:
         DisplayName: DataUpdated
         TopicName: ${self:custom.stage}-DataUpdate
 
+    DeleteReportTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: DeleteReport
+        TopicName: ${self:custom.stage}-DeleteReport
+
     TopicPolicy:
       Type: AWS::SNS::TopicPolicy
       Properties: 
@@ -45,6 +51,7 @@ resources:
         Topics: 
           - !Ref NewReportTopic
           - !Ref DataUpdateTopic
+          - !Ref DeleteReportTopic
     
     ProcessTopicPolicy:
       Type: AWS::IAM::ManagedPolicy
@@ -71,8 +78,15 @@ resources:
       Export:
         Name: ${self:custom.stage}-data-update-topic-arn
 
+    DeleteReportTopicOutput:
+      Value:
+        Ref: DeleteReportTopic
+      Export:
+        Name: ${self:custom.stage}-delete-report-topic-arn
+
     LambdaTopicAccessOutput:
       Value:
         Ref: ProcessTopicPolicy
       Export:
         Name: ${self:custom.stage}-process-lambda-topic-access-role
+    


### PR DESCRIPTION
Legger til SNS event slik at S3 cache av rapporter blir slettet.

PS: `test_reports.py` sin diff ble litt stygg, dette er fordi jeg har gitt den nytt navn `test_reports_repository.py` og så laget en _ny_ `test_reports.py` for å teste rapport-endepunktene i denne fila heller. _Ingen tester er slettet!_