### PR TITLE
Feature/person data split

### DIFF
--- a/packages/common/dataplattform/common/handlers/process.py
+++ b/packages/common/dataplattform/common/handlers/process.py
@@ -144,7 +144,7 @@ class PersonDataProcessHandler(ProcessHandler):
     def call_wrapped(self, s3_data, event):
         data, partitions, overwrite = super().call_wrapped(s3_data, event)
 
-        pdtables = self.wrapped_func_args['person_data_tables']
+        pdtables = self.wrapped_func_args.get('process', {}).get('person_data_tables', [])
 
         for table_name in pdtables:
             frame = data[table_name]

--- a/packages/common/dataplattform/common/handlers/process.py
+++ b/packages/common/dataplattform/common/handlers/process.py
@@ -153,11 +153,14 @@ class PersonalProcessHandler(ProcessHandler):
 
             del frame[self.id_type.value]
 
-        for table_name, table_partitions in partitions.items():
-            if "guid" not in table_partitions:
-                table_partitions.insert(0, "guid")
+            table_partition = partitions.get(table_name, [])
 
-            if self.id_type.value in table_partitions:
-                table_partitions.remove(self.id_type.value)
+            if "guid" not in table_partition:
+                table_partition.insert(0, "guid")
+
+            if self.id_type.value in table_partition:
+                table_partition.remove(self.id_type.value)
+
+            partitions[table_name] = table_partition
 
         return data, partitions, overwrite

--- a/packages/common/dataplattform/common/handlers/process.py
+++ b/packages/common/dataplattform/common/handlers/process.py
@@ -136,7 +136,7 @@ class ProcessHandler:
         return wrap
 
 
-class PersonalProcessHandler(ProcessHandler):
+class PersonDataProcessHandler(ProcessHandler):
     def __init__(self, id_type: PersonIdentifierType, access_path=None, bucket=None) -> None:
         super().__init__(access_path=access_path, bucket=bucket)
         self.id_type = id_type

--- a/packages/common/dataplattform/common/handlers/process.py
+++ b/packages/common/dataplattform/common/handlers/process.py
@@ -1,5 +1,6 @@
 from dataplattform.common.aws import S3, SNS
 from dataplattform.common.handlers import Response, verify_schema, make_wrapper_func
+from dataplattform.common.repositories.person_repository import PersonRepository, PersonIdentifierType
 from datetime import datetime
 import numpy as np
 import pandas as pd
@@ -52,30 +53,40 @@ class ProcessHandler:
         self.bucket = bucket
         self.wrapped_func: Dict[str, Callable] = {}
         self.wrapped_func_args: Dict[str, Any] = {}
+        self.s3 = S3(
+            access_path=access_path,
+            bucket=bucket)
 
     def __call__(self, event, context=None):
         assert 'process' in self.wrapped_func, \
             'ProcessHandler must wrap a process function'
 
-        s3 = S3(
-            access_path=self.access_path,
-            bucket=self.bucket)
+        s3_data = self.get_s3_data(event)
 
-        def load_event_data(event):
-            return [
-                s3.get(key) for key in
-                [
-                    record.get('body', None) for record in event.get('Records', [])
-                ] if key
-            ]
+        updated_tables = self.update_tables(
+            *self.call_wrapped(s3_data, event)
+        )
 
-        tables = self.wrapped_func['process'](load_event_data(event), event.get('Records', []))
-        partitions = self.wrapped_func_args.get(
-            'process', {}).get('partitions', {})
+        self.send_data_update_message(updated_tables)
 
-        overwrite = self.wrapped_func_args.get(
-            'process', {}).get('overwrite', False)
+        return Response().to_dict()
 
+    def get_s3_data(self, event):
+        return [
+            self.s3.get(key) for key in
+            [
+                record.get('body', None) for record in event.get('Records', [])
+            ] if key
+        ]
+
+    def call_wrapped(self, s3_data, event):
+        data = self.wrapped_func['process'](s3_data, event.get('Records', []))
+        partitions = self.wrapped_func_args.get('process', {}).get('partitions', {})
+        overwrite = self.wrapped_func_args.get('process', {}).get('overwrite', False)
+
+        return data, partitions, overwrite
+
+    def update_tables(self, tables, partitions, overwrite):
         updated_tables = []
 
         for table_name, frame in tables.items():
@@ -91,10 +102,10 @@ class ProcessHandler:
             table_partitions = partitions.get(table_name, [])
             frame = ensure_partitions_has_values(frame, table_partitions)
 
-            table_exists = check_exists(s3, frame, table_name, table_partitions)
+            table_exists = check_exists(self.s3, frame, table_name, table_partitions)
 
-            if overwrite and table_exists:
-                delete_table(s3, table_name)
+            if table_exists and overwrite:
+                delete_table(self.s3, table_name)
                 table_exists = False
 
             frame.to_parquet(f'structured/{table_name}',
@@ -104,15 +115,17 @@ class ProcessHandler:
                              partition_cols=table_partitions,
                              file_scheme='hive',
                              mkdirs=lambda x: None,  # noop
-                             open_with=s3.fs.open,
+                             open_with=self.s3.fs.open,
                              append=table_exists)
 
             updated_tables.append(table_name)
 
+        return updated_tables
+
+    def send_data_update_message(self, updated_tables):
         sns = SNS(environ.get('DATA_UPDATE_TOPIC'))
         sns.publish({'tables': updated_tables}, 'DataUpdate')
-
-        return Response().to_dict()
+        return True
 
     def process(self, partitions, overwrite=False):
         def wrap(f):
@@ -121,3 +134,20 @@ class ProcessHandler:
             return self.wrapped_func['process']
 
         return wrap
+
+
+class PersonalProcessHandler(ProcessHandler):
+    def __init__(self, id_type: PersonIdentifierType, access_path=None, bucket=None) -> None:
+        super().__init__(access_path=access_path, bucket=bucket)
+        self.id_type = id_type
+
+    def call_wrapped(self, s3_data, event):
+        data, partitions, overwrite = super().call_wrapped(s3_data, event)
+        data = self.transform_guid(data)
+        return data, partitions, overwrite
+
+    def transform_guid(self, data):
+        with PersonRepository() as repo:
+            return {f'{repo.get_guid_by(self.id_type, person)}/{k}': v
+                    for person, tables in data.items()
+                    for k, v in tables.items()}

--- a/packages/common/dataplattform/common/repositories/person_repository.py
+++ b/packages/common/dataplattform/common/repositories/person_repository.py
@@ -1,0 +1,35 @@
+from enum import Enum
+from os import environ
+import boto3
+from boto3.dynamodb.conditions import Attr
+
+
+class PersonIdentifierType(Enum):
+    GUID = 'guid'
+    EMAIL = 'email'
+    ALIAS = 'alias'
+    FULL_NAME = 'full_name'
+
+
+class PersonRepository():
+    table_name = 'personal_metadata_table'
+
+    def __enter__(self):
+        self.db = boto3.resource('dynamodb')
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        pass
+
+    @property
+    def table(self):
+        return self.db.Table(f'{environ.get("STAGE", "dev")}_{self.table_name}')
+
+    def get_guid_by(self, id_type: PersonIdentifierType, value: str):
+        if (id_type == PersonIdentifierType.GUID):
+            return value
+
+        response = self.table.scan(
+            FilterExpression=Attr(id_type.value).eq(value)
+        )
+        return response['Items'][0]['guid']

--- a/services/api/dataApi/common_lib/common/repositories/reports.py
+++ b/services/api/dataApi/common_lib/common/repositories/reports.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from os import environ
+from typing import List
 
 from boto3.dynamodb.conditions import Key
 from common.repositories.dynamo_db import DynamoDBRepository
@@ -18,7 +19,7 @@ class ReportsRepository(DynamoDBRepository):
         )
         return response['Item']
 
-    def get_by_tables(self, tables: [str]):
+    def get_by_tables(self, tables: List[str]):
 
         def compare_table(table):
             return table in tables

--- a/services/infrastructure/metadata/serverless.yml
+++ b/services/infrastructure/metadata/serverless.yml
@@ -1,0 +1,56 @@
+service: metadata
+
+custom:
+  stage: ${opt:stage, self:provider.stage}
+  publicBucketName: public-raw-storage-bucket
+  privateBucketName: private-raw-storage-bucket
+  stagePublicBucketName: ${self:custom.stage}-${self:custom.publicBucketName} 
+  stagePrivateBucketName: ${self:custom.stage}-${self:custom.privateBucketName} 
+  service: ${self:custom.stage}-${self:service}
+
+provider:
+  name: aws
+  stage: dev
+  region: eu-central-1
+  stackName: ${self:custom.service}
+
+resources:
+  Resources:
+    PersonalMetadataTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.stage}_personal_metadata_table
+        AttributeDefinitions:
+          - AttributeName: guid
+            AttributeType: S
+        KeySchema:
+          - AttributeName: guid
+            KeyType: HASH
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1
+        # SSESpecification: # Kryptering !?
+        
+    
+    PersonalMetadataTableAccess:
+      Type: AWS::IAM::ManagedPolicy
+      Properties:
+        Description: Access to ${self:custom.stage} Personal Metadata Table
+        ManagedPolicyName: ${self:custom.stage}-personal-metadata-table
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:Scan
+                - dynamodb:GetItem
+                - dynamodb:UpdateItem
+              Resource: !GetAtt PersonalMetadataTable.Arn
+
+
+  Outputs:
+    PersonalMetadataTableAccessOutput:
+      Value:
+        Ref: PersonalMetadataTableAccess
+      Export:
+        Name: ${self:custom.stage}-personal-metadata-table-access-policy

--- a/services/infrastructure/metadata/serverless.yml
+++ b/services/infrastructure/metadata/serverless.yml
@@ -2,10 +2,6 @@ service: metadata
 
 custom:
   stage: ${opt:stage, self:provider.stage}
-  publicBucketName: public-raw-storage-bucket
-  privateBucketName: private-raw-storage-bucket
-  stagePublicBucketName: ${self:custom.stage}-${self:custom.publicBucketName} 
-  stagePrivateBucketName: ${self:custom.stage}-${self:custom.privateBucketName} 
   service: ${self:custom.stage}-${self:service}
 
 provider:

--- a/templates/full_system/ingest_lambda.py
+++ b/templates/full_system/ingest_lambda.py
@@ -9,8 +9,20 @@ handler = IngestHandler()
 @handler.ingest()
 def ingest(event) -> Data:
     timestamp_now = datetime.now().timestamp()
-    d = [{'test': 'This is a test message', 'id': 1, 'time_precise': str(datetime.now().timestamp())},
-         {'test': 'This is also a test message', 'id': 2, 'time_precise': str(datetime.now().timestamp())}]
+    d = [
+        {
+            'alias': 'olanor',
+            'test': 'This is a test message',
+            'id': 1,
+            'time_precise': str(datetime.now().timestamp())
+        },
+        {
+            'alias': 'karnor',
+            'test': 'This is also a test message',
+            'id': 2,
+            'time_precise': str(datetime.now().timestamp())
+        }
+    ]
 
     d2 = Data(
         metadata=Metadata(timestamp=int(timestamp_now)),

--- a/templates/full_system/process_lambda.py
+++ b/templates/full_system/process_lambda.py
@@ -1,12 +1,15 @@
-from dataplattform.common.handlers.process import ProcessHandler
+from dataplattform.common.handlers.process import PersonalProcessHandler
+from dataplattform.common.repositories.person_repository import PersonIdentifierType
 import pandas as pd
 from typing import Dict
 
 
-handler = ProcessHandler()
+handler = PersonalProcessHandler(PersonIdentifierType.ALIAS)
 
 
 @handler.process(partitions={})
 def process(data, events) -> Dict[str, pd.DataFrame]:
     out_df = pd.concat([pd.json_normalize(d.json()['data'])for d in data])
-    return {'some_structured_data': out_df}
+    return {
+        'olanor': {'some_structured_data': out_df}
+        }

--- a/templates/full_system/process_lambda.py
+++ b/templates/full_system/process_lambda.py
@@ -10,4 +10,4 @@ handler = PersonalProcessHandler(PersonIdentifierType.ALIAS)
 @handler.process(partitions={})
 def process(data, events) -> Dict[str, pd.DataFrame]:
     out_df = pd.concat([pd.json_normalize(d.json()['data'])for d in data])
-    return {'person_data_test_4': out_df}
+    return {'person_data_test_5': out_df}

--- a/templates/full_system/process_lambda.py
+++ b/templates/full_system/process_lambda.py
@@ -7,7 +7,7 @@ from typing import Dict
 handler = PersonDataProcessHandler(PersonIdentifierType.ALIAS)
 
 
-@handler.process(partitions={})
+@handler.process(partitions={}, person_data_tables=['person_data_test_5'])
 def process(data, events) -> Dict[str, pd.DataFrame]:
     out_df = pd.concat([pd.json_normalize(d.json()['data'])for d in data])
     return {'person_data_test_5': out_df}

--- a/templates/full_system/process_lambda.py
+++ b/templates/full_system/process_lambda.py
@@ -1,22 +1,13 @@
-from dataplattform.common.handlers.process import PersonalProcessHandler, ProcessHandler
-from dataplattform.common.repositories.person_repository import PersonRepository, PersonIdentifierType
+from dataplattform.common.handlers.process import PersonalProcessHandler
+from dataplattform.common.repositories.person_repository import PersonIdentifierType
 import pandas as pd
 from typing import Dict
 
 
-# handler = PersonalProcessHandler(PersonIdentifierType.ALIAS)
-handler = ProcessHandler()
+handler = PersonalProcessHandler(PersonIdentifierType.ALIAS)
 
 
-@handler.process(partitions={'person_data_test_4': ['guid']})
+@handler.process(partitions={})
 def process(data, events) -> Dict[str, pd.DataFrame]:
-
-    def transform_to_guid(data):
-        with PersonRepository() as repo:
-            for item in data:
-                item['guid'] = repo.get_guid_by(PersonIdentifierType.ALIAS, item['alias'])
-                del item['alias']
-        return data
-
-    out_df = pd.concat([pd.json_normalize(transform_to_guid(d.json()['data']))for d in data])
+    out_df = pd.concat([pd.json_normalize(d.json()['data'])for d in data])
     return {'person_data_test_4': out_df}

--- a/templates/full_system/process_lambda.py
+++ b/templates/full_system/process_lambda.py
@@ -1,15 +1,22 @@
-from dataplattform.common.handlers.process import PersonalProcessHandler
-from dataplattform.common.repositories.person_repository import PersonIdentifierType
+from dataplattform.common.handlers.process import PersonalProcessHandler, ProcessHandler
+from dataplattform.common.repositories.person_repository import PersonRepository, PersonIdentifierType
 import pandas as pd
 from typing import Dict
 
 
-handler = PersonalProcessHandler(PersonIdentifierType.ALIAS)
+# handler = PersonalProcessHandler(PersonIdentifierType.ALIAS)
+handler = ProcessHandler()
 
 
-@handler.process(partitions={})
+@handler.process(partitions={'person_data_test_4': ['guid']})
 def process(data, events) -> Dict[str, pd.DataFrame]:
-    out_df = pd.concat([pd.json_normalize(d.json()['data'])for d in data])
-    return {
-        'olanor': {'some_structured_data': out_df}
-        }
+
+    def transform_to_guid(data):
+        with PersonRepository() as repo:
+            for item in data:
+                item['guid'] = repo.get_guid_by(PersonIdentifierType.ALIAS, item['alias'])
+                del item['alias']
+        return data
+
+    out_df = pd.concat([pd.json_normalize(transform_to_guid(d.json()['data']))for d in data])
+    return {'person_data_test_4': out_df}

--- a/templates/full_system/process_lambda.py
+++ b/templates/full_system/process_lambda.py
@@ -1,10 +1,10 @@
-from dataplattform.common.handlers.process import PersonalProcessHandler
+from dataplattform.common.handlers.process import PersonDataProcessHandler
 from dataplattform.common.repositories.person_repository import PersonIdentifierType
 import pandas as pd
 from typing import Dict
 
 
-handler = PersonalProcessHandler(PersonIdentifierType.ALIAS)
+handler = PersonDataProcessHandler(PersonIdentifierType.ALIAS)
 
 
 @handler.process(partitions={})

--- a/templates/full_system/serverless.yml
+++ b/templates/full_system/serverless.yml
@@ -177,6 +177,7 @@ resources: # The resources your functions use
         ManagedPolicyArns:
           - "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
           - !ImportValue ${self:custom.stage}-process-lambda-topic-access-role
+          - !ImportValue ${self:custom.stage}-personal-metadata-table-access-policy
         Policies:
           - PolicyName: ${self:custom.stage}-DatalakeIO-${self:service}
             PolicyDocument:


### PR DESCRIPTION
~~Her er mitt proof of concept.~~

~~Har endret full_system til å bruke den nye handleren, som gjør en liten endring i hvordan data prosseseres. Denne forventer et litt annet format enn før, nemlig:~~
```
{
    <user1>: {
        <table1>: DataFrame,
        <table2>: DataFrame
    },
    <user2>: {
        <table1>: DataFrame,
        <table2>: DataFrame
    }
}
```
~~Der `<user1>` kan (for øyeblikket) være en av `guid`, `email`, `alias` eller `full_name`, se også packages/common/dataplattform/common/repositories/person_repository.py#L7~~

~~Det vil dermed være de individuelle handlerene sin oppgave å splitte data på bruker, så samme måte som de er ansvarlige for å splitte på tabeller i dag.~~

Løsningen som er skissert over er _ikke_ løsningen vi endte opp med! 