### PR TITLE
Feature/update crawler on new table

### DIFF
--- a/packages/common/dataplattform/common/aws.py
+++ b/packages/common/dataplattform/common/aws.py
@@ -42,7 +42,6 @@ class Glue:
 
     def update_crawler(self, table_name):
         crawler_metadata = self.get_crawler()
-
         if crawler_metadata is not None:
             current_targets = crawler_metadata.get('Crawler', {}).get('Targets', {}).get('S3Targets', [])
             path = f's3://{self.bucket}/{self.access_path}structured/{table_name}'

--- a/packages/common/dataplattform/common/aws.py
+++ b/packages/common/dataplattform/common/aws.py
@@ -48,10 +48,10 @@ class Glue:
 
             if path not in [target.get('Path', None) for target in current_targets]:
                 targets = [*current_targets, {
-                    'Path': path,
-                    'Exclusions': ['*_metadata']
-                }
-                           ]
+                        'Path': path,
+                        'Exclusions': ['*_metadata']
+                    }
+                ]
                 # Will not update if crawler is running
                 try:
                     self.glue.update_crawler(
@@ -66,6 +66,7 @@ class Glue:
             self.glue.start_crawler(Name=self.crawler_name)
         except ClientError as e:
             print(e)
+
 
 class S3:
     def __init__(self, access_path: str = None, bucket: str = None):

--- a/packages/common/dataplattform/common/aws.py
+++ b/packages/common/dataplattform/common/aws.py
@@ -24,6 +24,50 @@ class S3Result:
         return loads(self.res['Body'].read(), **json_args) if self.res else None
 
 
+class Glue:
+    def __init__(self, access_level=None, access_path=None):
+        self.access_level = access_level or environ.get('ACCESS_LEVEL')
+        self.access_path = access_path or environ.get('ACCESS_PATH')
+        self.bucket = environ.get('DATALAKE')
+        self.stage = environ.get('STAGE')
+        self.glue = boto3.client('glue')
+        self.crawler_name = f'{self.stage}_level_{self.access_level[-1]}_crawler'
+
+    def get_crawler(self):
+        try:
+            res = self.glue.get_crawler(Name=self.crawler_name)
+            return res
+        except ClientError as e:
+            print(e)
+
+    def update_crawler(self, table_name):
+        crawler_metadata = self.get_crawler()
+
+        if crawler_metadata is not None:
+            current_targets = crawler_metadata.get('Crawler', {}).get('Targets', {}).get('S3Targets', [])
+            path = f's3://{self.bucket}/{self.access_path}structured/{table_name}'
+
+            if path not in [target.get('Path', None) for target in current_targets]:
+                targets = [*current_targets, {
+                    'Path': path,
+                    'Exclusions': ['*_metadata']
+                }
+                           ]
+                # Will not update if crawler is running
+                try:
+                    self.glue.update_crawler(
+                        Name=self.crawler_name,
+                        Targets={'S3Targets': targets},
+                    )
+                except ClientError as e:
+                    print(e)
+
+    def start(self):
+        try:
+            self.glue.start_crawler(Name=self.crawler_name)
+        except ClientError as e:
+            print(e)
+
 class S3:
     def __init__(self, access_path: str = None, bucket: str = None):
         self.access_path = environ.get("ACCESS_PATH") if access_path is None else access_path

--- a/packages/common/dataplattform/common/handlers/process.py
+++ b/packages/common/dataplattform/common/handlers/process.py
@@ -1,4 +1,4 @@
-from dataplattform.common.aws import S3, SNS
+from dataplattform.common.aws import S3, SNS, Glue
 from dataplattform.common.handlers import Response, verify_schema, make_wrapper_func
 from dataplattform.common.repositories.person_repository import PersonRepository, PersonIdentifierType
 from datetime import datetime
@@ -117,6 +117,9 @@ class ProcessHandler:
                              mkdirs=lambda x: None,  # noop
                              open_with=self.s3.fs.open,
                              append=table_exists)
+
+            glue = Glue()
+            glue.update_crawler(table_name)
 
             updated_tables.append(table_name)
 

--- a/packages/common/tests/test_aws.py
+++ b/packages/common/tests/test_aws.py
@@ -3,7 +3,6 @@ from os import environ
 from pytest import mark
 import re
 from json import loads
-import boto3
 from pytest import fixture
 import datetime
 
@@ -64,14 +63,14 @@ def glue(mocker, class_fixture):
 
 def test_s3_default():
     s3 = aws.S3()
-    assert s3.access_path == environ.get("ACCESS_PATH") and\
-        s3.bucket == environ.get('DATALAKE')
+    assert s3.access_path == environ.get("ACCESS_PATH") and \
+           s3.bucket == environ.get('DATALAKE')
 
 
 def test_s3_default_overrides():
     s3 = aws.S3(access_path='/abc', bucket='myBucket')
-    assert s3.access_path == '/abc' and\
-        s3.bucket == 'myBucket'
+    assert s3.access_path == '/abc' and \
+           s3.bucket == 'myBucket'
 
 
 @mark.parametrize('path, expected_key_pattern', [
@@ -138,9 +137,9 @@ def test_s3_put_raw_data_with_path(s3_bucket):
 
 def test_ssm_default():
     ssm = aws.SSM()
-    assert ssm.path.startswith('/') and\
-        environ.get('STAGE') in ssm.path and\
-        ssm.path.endswith(environ.get('SERVICE'))
+    assert ssm.path.startswith('/') and \
+           environ.get('STAGE') in ssm.path and \
+           ssm.path.endswith(environ.get('SERVICE'))
 
 
 def test_ssm_get_paramenter(ssm_client):
@@ -230,7 +229,7 @@ def test_s3_get_empty():
     s3 = aws.S3(access_path='/data')
     res = s3.get('test.txt')
     assert res.raw is None and \
-        'NoSuchKey' in str(res.error)
+           'NoSuchKey' in str(res.error)
 
 
 def test_s3_get_absolute_path_data(s3_bucket):
@@ -312,5 +311,6 @@ def test_sns_send_message(sqs_queue, sns_topic):
 
 def test_update_crawler(glue):
     glue_handler = aws.Glue(access_level="1", access_path="s3://dev-datalake-datalake/data/level-1/test_table")
-    res = glue_handler.update_crawler("test-table2")
-    assert any(["test-table2" in targets['Path'] for targets in glue.crawlers['dev_level_1_crawler']['Targets']['S3Targets']])
+    glue_handler.update_crawler("test-table2")
+    assert any(
+        ["test-table2" in targets['Path'] for targets in glue.crawlers['dev_level_1_crawler']['Targets']['S3Targets']])

--- a/packages/testing/dataplattform/testing/plugin.py
+++ b/packages/testing/dataplattform/testing/plugin.py
@@ -34,6 +34,7 @@ def pytest_load_initial_conftests(args, early_config, parser):
         ('SNS_TOPIC_NAME', 'test_sns_topic'),
         ('PUBLIC_PREFIX', 'public/images'),
         ('PRIVATE_PREFIX', 'private/cvs'),
+        ('ACCESS_LEVEL', 'level-1')
     ]
     for key, value in default_env:
         if key not in environ:

--- a/services/ingestion/cvPartner/serverless.yml
+++ b/services/ingestion/cvPartner/serverless.yml
@@ -121,6 +121,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: !ImportValue ${self:custom.stage}-data-update-topic-arn
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
 
 resources: # The resources your functions use
@@ -291,6 +292,19 @@ resources: # The resources your functions use
                       - "" 
                       - - !ImportValue ${self:custom.stage}-datalakeArn
                         - '*'
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
 
     EventQueue:
       Type: AWS::SQS::Queue

--- a/services/ingestion/gitHub/serverless.yml
+++ b/services/ingestion/gitHub/serverless.yml
@@ -146,6 +146,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: !ImportValue ${self:custom.stage}-data-update-topic-arn
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
 
 resources: # The resources your functions use
@@ -316,7 +317,20 @@ resources: # The resources your functions use
                     - 'athena:StartQueryExecution'
                     - 'athena:GetQueryExecution'
                     - 'athena:GetQueryResults'
-                  Resource: !Sub 'arn:aws:athena:#{AWS::Region}:#{AWS::AccountId}:workgroup/primary' 
+                  Resource: !Sub 'arn:aws:athena:#{AWS::Region}:#{AWS::AccountId}:workgroup/primary'
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
     EventQueue:
       Type: AWS::SQS::Queue
       Properties:

--- a/services/ingestion/googleEvent/serverless.yml
+++ b/services/ingestion/googleEvent/serverless.yml
@@ -114,6 +114,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: !ImportValue ${self:custom.stage}-data-update-topic-arn
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
 
 resources: # The resources your functions use
@@ -213,6 +214,19 @@ resources: # The resources your functions use
                         - ""
                         - - !ImportValue ${self:custom.stage}-datalakeArn
                           - '*'
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
 
     EventQueue:
       Type: AWS::SQS::Queue

--- a/services/ingestion/googleForms/serverless.yml
+++ b/services/ingestion/googleForms/serverless.yml
@@ -124,6 +124,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: !ImportValue ${self:custom.stage}-data-update-topic-arn
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
 
 resources: # The resources your functions use
@@ -214,6 +215,19 @@ resources: # The resources your functions use
                       - "" 
                       - - !ImportValue ${self:custom.stage}-datalakeArn
                         - '*'
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
     
     EventQueue:
       Type: AWS::SQS::Queue

--- a/services/ingestion/googleSheets/serverless.yml
+++ b/services/ingestion/googleSheets/serverless.yml
@@ -124,6 +124,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: !ImportValue ${self:custom.stage}-data-update-topic-arn
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
     
 
@@ -215,6 +216,19 @@ resources: # The resources your functions use
                       - "" 
                       - - !ImportValue ${self:custom.stage}-datalakeArn
                         - '*'
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
     
     EventQueue:
       Type: AWS::SQS::Queue

--- a/services/ingestion/jiraSales/serverless.yml
+++ b/services/ingestion/jiraSales/serverless.yml
@@ -119,6 +119,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: !ImportValue ${self:custom.stage}-data-update-topic-arn
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
 
 resources: # The resources your functions use
@@ -217,6 +218,19 @@ resources: # The resources your functions use
                       - "" 
                       - - !ImportValue ${self:custom.stage}-datalakeArn
                         - '*'
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
     EventQueue:
       Type: AWS::SQS::Queue
       Properties:

--- a/services/ingestion/knowitLabs/serverless.yml
+++ b/services/ingestion/knowitLabs/serverless.yml
@@ -114,6 +114,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: !ImportValue ${self:custom.stage}-data-update-topic-arn
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
 
 resources: # The resources your functions use
@@ -233,7 +234,20 @@ resources: # The resources your functions use
                     - 'athena:StartQueryExecution'
                     - 'athena:GetQueryExecution'
                     - 'athena:GetQueryResults'
-                  Resource: !Sub 'arn:aws:athena:#{AWS::Region}:#{AWS::AccountId}:workgroup/primary' 
+                  Resource: !Sub 'arn:aws:athena:#{AWS::Region}:#{AWS::AccountId}:workgroup/primary'
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
 
     EventQueue:
       Type: AWS::SQS::Queue

--- a/services/ingestion/slack/serverless.yml
+++ b/services/ingestion/slack/serverless.yml
@@ -118,6 +118,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: !ImportValue ${self:custom.stage}-data-update-topic-arn
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
 
 resources: # The resources your functions use
@@ -216,6 +217,19 @@ resources: # The resources your functions use
                       - "" 
                       - - !ImportValue ${self:custom.stage}-datalakeArn
                         - '*'
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
 
     EventQueue:
       Type: AWS::SQS::Queue

--- a/services/ingestion/twitter/serverless.yml
+++ b/services/ingestion/twitter/serverless.yml
@@ -114,6 +114,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: !ImportValue ${self:custom.stage}-data-update-topic-arn
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
 
 resources: # The resources your functions use
@@ -248,6 +249,19 @@ resources: # The resources your functions use
                       - ""
                       - - !ImportValue ${self:custom.stage}-datalakeArn
                         - /${self:custom.accessPath}*
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
 
     EventQueue:
       Type: AWS::SQS::Queue

--- a/services/ingestion/ubwFagtime/serverless.yml
+++ b/services/ingestion/ubwFagtime/serverless.yml
@@ -114,6 +114,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: !ImportValue ${self:custom.stage}-data-update-topic-arn
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
 
 resources: # The resources your functions use
@@ -235,6 +236,19 @@ resources: # The resources your functions use
                         - ""
                         - - !ImportValue ${self:custom.stage}-datalakeArn
                           - '*'
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
 
     EventQueue:
       Type: AWS::SQS::Queue

--- a/services/ingestion/yrWeather/serverless.yml
+++ b/services/ingestion/yrWeather/serverless.yml
@@ -114,6 +114,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: !ImportValue ${self:custom.stage}-data-update-topic-arn
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
 
 resources: # The resources your functions use
@@ -212,6 +213,19 @@ resources: # The resources your functions use
                         - ""
                         - - !ImportValue ${self:custom.stage}-datalakeArn
                           - '*'
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
 
     EventQueue:
       Type: AWS::SQS::Queue

--- a/templates/full_system/serverless.yml
+++ b/templates/full_system/serverless.yml
@@ -117,6 +117,7 @@ functions:
       ACCESS_PATH: ${self:custom.accessPath}
       DEFAULT_DATABASE: ${self:custom.editable.databaseName}
       DATA_UPDATE_TOPIC: ${self:custom.snsUpdateTopic}
+      ACCESS_LEVEL: ${self:custom.editable.accessLevel}
     tags: # Tag for this function. Every function are tagged with stage by default
 
 resources: # The resources your functions use
@@ -195,6 +196,19 @@ resources: # The resources your functions use
                       - "" 
                       - - !ImportValue ${self:custom.stage}-datalakeArn
                         - /${self:custom.accessPath}*
+          - PolicyName: ${self:custom.stage}-glue-${self:service}-role
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - glue:GetCrawler
+                    - glue:UpdateCrawler
+                  Resource:
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:catalog'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:database/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:table/${self:custom.stage}_*'
+                    - !Sub 'arn:aws:glue:#{AWS::Region}:#{AWS::AccountId}:crawler/${self:custom.stage}_*'
     EventQueue:
       Type: AWS::SQS::Queue
       Properties: 


### PR DESCRIPTION
closes knowit/Dataplattform-issues#246

Kanskje en litt overkomplisert løsning for å sikre potensielle race conditions.

Problemet med å oppdatere krawleren, er at den ikke kan oppdateres men den kjører.
Hvis to events samtidig sjekker om den kjører, begge ser at den er "READY", og begge oppdaterer og kjører samtidig, kan dette bli krøll.

Når nye tabeller blir oprettet, blir en melding sendt til en SQS kø.
En lambda tar imot meldinger fra denne køen i serie, stopper crawleren hvis den kjører, venter til den er klar, og oppdaterer og kjører.