### PR TITLE
pin requests to get rid of dependency warning

### DIFF
--- a/packages/cli/setup.py
+++ b/packages/cli/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 setup(
     name='dataplattform_cli',
     packages=find_namespace_packages(include=['dataplattform.*']),
-    install_requires=['boto3', 'moto==1.3.14', 'requests',
+    install_requires=['boto3', 'moto==1.3.14', 'requests==2.23',
                       'python-dateutil', 'pandas', 'fastparquet'],
     dependency_links=['file:../common', 'file:../query'],
     entry_points={

--- a/services/ingestion/activeDirectory/requirements.txt
+++ b/services/ingestion/activeDirectory/requirements.txt
@@ -1,2 +1,2 @@
-requests
+requests==2.23
 file:../../../packages/common

--- a/services/ingestion/cvPartner/requirements.txt
+++ b/services/ingestion/cvPartner/requirements.txt
@@ -1,2 +1,2 @@
-requests
+requests==2.23
 file:../../../packages/common

--- a/services/ingestion/gitHub/requirements.txt
+++ b/services/ingestion/gitHub/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests==2.23
 file:../../../packages/common
 file:../../../packages/query

--- a/services/ingestion/knowitLabs/requirements.txt
+++ b/services/ingestion/knowitLabs/requirements.txt
@@ -1,5 +1,5 @@
 file:../../../packages/common
 file:../../../packages/query
-requests
+requests==2.23
 beautifulsoup4
 lxml

--- a/services/ingestion/slack/requirements.txt
+++ b/services/ingestion/slack/requirements.txt
@@ -1,3 +1,3 @@
 file:../../../packages/common
 emojis
-requests
+requests==2.23

--- a/services/ingestion/yrWeather/requirements.txt
+++ b/services/ingestion/yrWeather/requirements.txt
@@ -1,4 +1,4 @@
 file:../../../packages/common
-requests
+requests==2.23
 xmltodict
 numpy


### PR DESCRIPTION
Fikk denne warningen i cloudwatch for alle process lambdaer som brukte requests biblioteket: `RequestsDependencyWarning: urllib3 (1.26.3) or chardet (4.0.0) doesn't match a supported version!`

Forsvinner ved å pinne requests til versjon 2.23