### PR TITLE
Add timeout to process function

### DIFF
--- a/services/ingestion/slack/serverless.yml
+++ b/services/ingestion/slack/serverless.yml
@@ -106,6 +106,7 @@ functions:
       - !ImportValue ${self:custom.stage}-numpyDepLayer-arn
       - !ImportValue ${self:custom.stage}-pandasDepLayer-arn
     name: ${self:custom.stage}-${self:service}-process # Always begin name with stage
+    timeout: ${self:custom.editable.timeout}
     description: ${self:custom.editable.description}
     role: !GetAtt ProcessLambdaRole.Arn
     package:


### PR DESCRIPTION
Closes knowit/Dataplattform-issues#321

Timeout variabelen var kun brukt til SQS og ikke Lambda'en, slik at feilen vedvarte. 