### PR TITLE
Skriv om så KMS opprettes manuelt av rotbruker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ services/infrastructure/deploymentBucket/config.yml
 
 # Sandbox
 **/my_name_servers.*
+**/my_key_policy.*

--- a/packages/cli/dataplattform/cli/__init__.py
+++ b/packages/cli/dataplattform/cli/__init__.py
@@ -15,7 +15,8 @@ def main():
         'deploy',
         'configure',
         'prepare-sandbox',
-        'test'
+        'test',
+        'generate-key-policy'
     ]
 
     parser = ArgumentParser('dataplattform')

--- a/packages/cli/dataplattform/cli/commands/generate_key_policy.py
+++ b/packages/cli/dataplattform/cli/commands/generate_key_policy.py
@@ -1,0 +1,78 @@
+from argparse import ArgumentParser, Namespace
+import boto3
+import json
+
+
+def get_account_id():
+    client = boto3.client("sts")
+    return client.get_caller_identity()["Account"]
+
+
+def init(parser: ArgumentParser):
+    parser.add_argument('-r', '--roles', default=[], type=str, nargs='*')
+
+
+def run(args: Namespace, _):
+    statement = [
+        {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::" + str(get_account_id()) + ":root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
+            "Sid": "Enable encryption for loggroup",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "logs.eu-central-1.amazonaws.com"
+            },
+            "Action": [
+                "kms:Encrypt*",
+                "kms:Decrypt*",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:Describe*"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "ArnLike": {
+                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:eu-central-1:" + str(get_account_id()) + ":log-group:/aws-glue/crawlers-role/Level4GlueRole-KMSGlueEncryptionConfigurations"
+                }
+            }
+        }
+    ]
+
+    for role in args.roles:
+        statement.append({
+            "Sid": "Enable encryption for " + str(role),
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "logs.eu-central-1.amazonaws.com"
+            },
+            "Action": [
+                "kms:Encrypt*",
+                "kms:Decrypt*",
+                "kms:DescribeKey*",
+                "kms:GenerateDataKey*",
+                "kms:ListKeys*"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "aws:PrincipalArn": "arn:aws:iam::" + str(get_account_id()) + ":role/" + str(role)
+                }
+            }
+        })
+
+    policy = {
+        "Version": "2012-10-17",
+        "Id": "kms-key-policy-" + str(get_account_id()),
+        "Statement": statement,
+    }
+
+    with open("my_key_policy.json", "w") as outfile:
+        json.dump(policy, outfile, indent=4)
+

--- a/services/infrastructure/athena/serverless.yml
+++ b/services/infrastructure/athena/serverless.yml
@@ -214,22 +214,6 @@ resources:
                     - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog
                     - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/${self:custom.stage}_${self:custom.editable.databaseName}_database
                     - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/${self:custom.stage}_${self:custom.editable.databaseName}_database/*
-          - PolicyName: ${self:custom.stage}-EncryptedBucketKMS-${self:service}
-            PolicyDocument:
-              Version: "2012-10-17"
-              Statement:
-                - Effect: Allow
-                  Action:
-                    - kms:Encrypt
-                    - kms:Decrypt
-                    - kms:DescribeKey
-                    - kms:ListKeys
-                    - kms:GenerateDataKey
-                  Resource:
-                    Fn::Join:
-                      - ""
-                      - - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/
-                        - !ImportValue ${self:custom.stage}-KMS-KeyID
           - PolicyName: ${self:custom.stage}-Athena-${self:service}
             PolicyDocument:
               Version: "2012-10-17"

--- a/services/infrastructure/glue/serverless.yml
+++ b/services/infrastructure/glue/serverless.yml
@@ -207,22 +207,6 @@ resources:
                   Resource:
                     - !Sub arn:aws:s3:::${self:custom.stage}-kmsbucket-${AWS::AccountId}
                     - !Sub arn:aws:s3:::${self:custom.stage}-kmsbucket-${AWS::AccountId}/*
-          - PolicyName: ${self:custom.stage}-KMSKeyAccess-${self:service}
-            PolicyDocument:
-              Version: "2012-10-17"
-              Statement:
-                - Effect: Allow
-                  Action:
-                    - kms:Encrypt
-                    - kms:Decrypt
-                    - kms:DescribeKey
-                    - kms:ListKeys
-                    - kms:GenerateDataKey
-                  Resource:
-                    Fn::Join:
-                      - ""
-                      - - !Sub 'arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/'
-                        - !ImportValue ${self:custom.stage}-KMS-KeyID
 
   Outputs:
     Level1GlueAccessOutput:

--- a/services/infrastructure/kms/serverless.yml
+++ b/services/infrastructure/kms/serverless.yml
@@ -20,67 +20,6 @@ provider:
 
 resources:
   Resources:
-    KMSBucketKey:
-      Type: AWS::KMS::Key
-      Properties:
-        Description: An example symmetric KMS key
-        EnableKeyRotation: true
-        PendingWindowInDays: 20
-        KeyPolicy:
-          Id: key-default-2
-          Version: "2012-10-17"
-          Statement:
-            - Sid: "Enable IAM User Permissions"
-              Effect: Allow
-              Principal:
-                AWS: !Sub arn:aws:iam::${AWS::AccountId}:user/${self:custom.stage}-deploy-bot
-              Action:
-                - kms:Describe*
-                - kms:Put*
-                - kms:Create*
-                - kms:Update*
-                - kms:Enable*
-                - kms:Revoke*
-                - kms:List*
-                - kms:Disable*
-                - kms:Get*
-                - kms:Delete*
-                - kms:ScheduleKeyDeletion
-                - kms:CancelKeyDeletion
-                - kms:TagResource
-                - kms:UntagResource
-              Resource: "*"
-            - Sid: "Enable IAM User Permissions"
-              Effect: Allow
-              Principal:
-                AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
-              Action:
-                - kms:*
-              Resource: "*"
-            - Sid: "Enable encryption for loggroup"
-              Effect: Allow
-              Principal:
-                Service:
-                  - logs.eu-central-1.amazonaws.com
-              Action:
-                - kms:Encrypt*
-                - kms:Decrypt*
-                - kms:ReEncrypt*
-                - kms:GenerateDataKey*
-                - kms:Describe*
-              Resource: "*"
-              Condition:
-                ArnLike:
-                  kms:EncryptionContext:aws:logs:arn:
-                    Fn::Join:
-                      - ""
-                      - - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/"
-                        - "aws-glue/crawlers-role/Level4GlueRole-KMSGlueEncryptionConfigurations"
-    KeyAlias:
-      Type: "AWS::KMS::Alias"
-      Properties:
-        AliasName: alias/KMSBucketKey
-        TargetKeyId: !Ref KMSBucketKey
     EncryptedS3Bucket:
       Type: "AWS::S3::Bucket"
       Properties:
@@ -91,7 +30,7 @@ resources:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: "aws:kms"
-                KMSMasterKeyID: !Ref KMSBucketKey
+                KMSMasterKeyID: !Sub "${ssm:/${self:custom.stage}/kms/key-id}"
               BucketKeyEnabled: true
         PublicAccessBlockConfiguration:
           BlockPublicAcls: true
@@ -102,6 +41,6 @@ resources:
   Outputs:
     KMSKey:
       Description: KMS key ID used for encryptedbucket
-      Value: !Ref KMSBucketKey
+      Value: !Sub "${ssm:/${self:custom.stage}/kms/key-id}"
       Export:
         Name: ${self:custom.stage}-KMS-KeyID


### PR DESCRIPTION
Det er et sikkerhetsproblem at deploy-brukeren har full tilgang til KMS nøkkel. Infrastrukturkoden er skrevet om slik at nøkkelen må opprettes manuelt av rotbruker, og de rollene som skal ha tilgang må deklareres direkte i nøkkelen. Det er også laget en kommando som genererer nøkkelpolicy.

Dokumentasjon for oppsett er skrevet her:
https://github.com/knowit/Dataplattform-issues/wiki/Dataplattform:-Deploy-til-sandbox#lage-kms-n%C3%B8kkel
https://github.com/knowit/Dataplattform-issues/wiki/Dataplattform:-Parametre-i-AWS#kms