### PR TITLE
Sett serverless versjon for Github actions til å være 2.49.0

### DIFF
--- a/.config/.serverless
+++ b/.config/.serverless
@@ -1,1 +1,1 @@
-SERVERLESS_VERSION: serverless@1.69.0
+SERVERLESS_VERSION: serverless@2.49.0


### PR DESCRIPTION
Det er mange tjenester som ikke får til å deployes med versjon 1.69.0.

Siden utviklingsmiljøet settes opp til 2.49.0 ser jeg ingen grunn til å ha gammel versjon i github actions