### PR TITLE
CI/CD flyt deployer alle services ved release dersom ingen tidligere release finnes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ name: Deploy dataplattform
 on:
   release:
     types: [published]
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -28,12 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: fix/deploy-first-release
           fetch-depth: 0
-
-      - name: Test stuff
-        run: |
-          echo "Test"
 
       - name: 'Get changed files (push)'
         id: changed_files_push
@@ -79,5 +73,4 @@ jobs:
         if: ${{ steps.get_changed_services.outputs.should_deploy == 'true' }}
         run: |
           echo -e "Deploying services to stage $STAGE\n"
-          echo "$SERVICES"
-#          dataplattform deploy -s $SERVICES --stage $STAGE
+          dataplattform deploy -s $SERVICES --stage $STAGE

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ env:
   STAGE: ${{ github.event_name == 'release' && 'prod' || 'dev' }}
   EVENT_TYPE: ${{ github.event_name }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  CURRENT_BRANCH_NAME: ${{ git.ref }}
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: main
+          ref: fix/deploy-first-release
           fetch-depth: 0
+
+      - name: Test stuff
+        run: |
+          echo "Test"
 
       - name: 'Get changed files (push)'
         id: changed_files_push
@@ -74,4 +78,5 @@ jobs:
         if: ${{ steps.get_changed_services.outputs.should_deploy == 'true' }}
         run: |
           echo -e "Deploying services to stage $STAGE\n"
-          dataplattform deploy -s $SERVICES --stage $STAGE
+          echo "$SERVICES"
+#          dataplattform deploy -s $SERVICES --stage $STAGE

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ env:
   STAGE: ${{ github.event_name == 'release' && 'prod' || 'dev' }}
   EVENT_TYPE: ${{ github.event_name }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  CURRENT_BRANCH_NAME: ${{ git.ref }}
+  CURRENT_BRANCH_NAME: ${{ github.ref }}
 
 jobs:
   deploy:

--- a/.workflow-scripts/utils/test/git_utils.bats
+++ b/.workflow-scripts/utils/test/git_utils.bats
@@ -45,6 +45,19 @@ setup() {
   [ "${lines[2]}" == "some/path/file_3" ]
 }
 
+@test "list_all_files_in_branch" {
+  run list_all_files_in_branch
+  [ "$status" -eq 1 ]
+  [ "$output" == "Missing environment variable: CURRENT_BRANCH_NAME" ]
+
+  export CURRENT_BRANCH_NAME="main"
+  run list_all_files_in_branch
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" == "some/path/file_1" ]
+  [ "${lines[1]}" == "some/path/file_2" ]
+  [ "${lines[2]}" == "some/path/file_3" ]
+}
+
 @test "get_changed_files_in_release" {
   run get_changed_files_in_release
   [ "$status" -eq 0 ]

--- a/.workflow-scripts/utils/test/setup/setup_git.sh
+++ b/.workflow-scripts/utils/test/setup/setup_git.sh
@@ -7,7 +7,7 @@ function setup_git {
     if [[ "$ARG_1" == "show-ref" ]]
     then
       echo "abseafeawmawlwaef $ARG_2"
-    elif [[ "$ARG_1" == "diff" ]]
+    elif [[ "$ARG_1" == "diff" || "$ARG_1" == "ls-tree" ]]
     then
       echo -e "some/path/file_1\nsome/path/file_2\nsome/path/file_3"
     fi


### PR DESCRIPTION
Deploy flyten ved release tok utgangspunkt i diff mellom nåværende og forrige release. Disse endringene gjør at diff mellom nåværende og forrige release blir til alle filer i repoet dersom ingen tidligere release finnes.