### PR TITLE
Fiks feilende ingestorer

### DIFF
--- a/packages/common/dataplattform/common/helper.py
+++ b/packages/common/dataplattform/common/helper.py
@@ -23,4 +23,4 @@ def save_document(http_request, filename, filetype, private=True):
 
 def empty_content_in_path(bucket, prefix, delete_all_versions=False, filter_val=None):
     s3 = S3(bucket=bucket, access_path='')
-    s3.empty_content_in_path(path=prefix, delete_all_versions=delete_all_versions, filter_val=filter_val)
+    s3.empty_content_in_path(s3_path=prefix, delete_all_versions=delete_all_versions, filter_val=filter_val)

--- a/packages/common/tests/test_aws.py
+++ b/packages/common/tests/test_aws.py
@@ -89,7 +89,7 @@ def test_s3_key(path, expected_key_pattern):
         schema.Data(
             metadata=schema.Metadata(timestamp=1234),
             data=''),
-        path=path)
+        s3_path=path)
 
     assert re.fullmatch(expected_key_pattern, key)
 
@@ -109,7 +109,7 @@ def test_s3_put_raw_data(s3_bucket):
     s3 = aws.S3()
     input_bytes = 'some bytes'
     ext = 'txt'
-    key = s3.put_raw(input_bytes, path='', ext=ext)
+    key = s3.put_raw(input_bytes, s3_path='', ext=ext)
     res = s3_bucket.Object(key).get()['Body'].read().decode('utf-8')
 
     assert res == input_bytes
@@ -120,7 +120,7 @@ def test_s3_put_raw_data_none(s3_bucket):
     s3 = aws.S3()
     input_bytes = None
     ext = 'txt'
-    key = s3.put_raw(input_bytes, path='', ext=ext)
+    key = s3.put_raw(input_bytes, s3_path='', ext=ext)
     assert key is None
 
 
@@ -136,7 +136,7 @@ def test_s3_put_raw_data_with_path(s3_bucket):
     s3 = aws.S3(access_path='')
     input_bytes = 'some_bytes'
     input_key = 'test_file.txt'
-    key = s3.put_raw(input_bytes, key=input_key, path='test')
+    key = s3.put_raw(input_bytes, key=input_key, s3_path='test')
     assert key == f'test/{input_key}'
 
 
@@ -154,7 +154,7 @@ def test_ssm_get_paramenter(ssm_client):
         Type='String',
         Tier='Standard')
 
-    ssm = aws.SSM(path='/test')
+    ssm = aws.SSM(ssm_path='/test')
     assert ssm.get('param') == 'hello world'
 
 
@@ -165,7 +165,7 @@ def test_ssm_get_paramenter_strip_whitespaces(ssm_client):
         Type='String',
         Tier='Standard')
 
-    ssm = aws.SSM(path='/test')
+    ssm = aws.SSM(ssm_path='/test')
     assert ssm.get('param') == 'hello world'
 
 
@@ -176,7 +176,7 @@ def test_ssm_get_list_1_paramenter(ssm_client):
         Type='StringList',
         Tier='Standard')
 
-    ssm = aws.SSM(path='/test')
+    ssm = aws.SSM(ssm_path='/test')
     assert ssm.get('param') == ['hello world']
 
 
@@ -187,7 +187,7 @@ def test_ssm_get_list_2_paramenter(ssm_client):
         Type='StringList',
         Tier='Standard')
 
-    ssm = aws.SSM(path='/test')
+    ssm = aws.SSM(ssm_path='/test')
     assert ssm.get('param') == ['hello', 'world']
 
 
@@ -198,7 +198,7 @@ def test_ssm_get_list_2_paramenter_strip_whitespaces(ssm_client):
         Type='StringList',
         Tier='Standard')
 
-    ssm = aws.SSM(path='/test')
+    ssm = aws.SSM(ssm_path='/test')
     assert ssm.get('param') == ['hello', 'world']
 
 
@@ -206,7 +206,7 @@ def test_SSM_put():
     ssm = aws.SSM()
     ssm.put(name='/test/param',
             value='hello world')
-    ssm = aws.SSM(path='/test')
+    ssm = aws.SSM(ssm_path='/test')
     assert ssm.get('param') == 'hello world'
 
 
@@ -214,7 +214,7 @@ def test_SSM_put_overwrite_true():
     ssm = aws.SSM()
     ssm.put(name='/test/param',
             value='hello world')
-    ssm = aws.SSM(path='/test')
+    ssm = aws.SSM(ssm_path='/test')
     assert ssm.get('param') == 'hello world'
     ssm.put(name='param',
             value='hello new world',

--- a/services/api/dataApi/serverless.yml
+++ b/services/api/dataApi/serverless.yml
@@ -19,6 +19,7 @@ custom:
     packRequirements: false
     pythonBin: python
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     slim: true
     slimPatternsAppendDefaults: false
@@ -137,9 +138,6 @@ functions:
     package:
       include:
         - 'functions/cache_deleter.py'
-    # destinations: # TODO
-    #   onSuccess: xxx:xxx:target
-    #   onFailure: xxx:xxx:target
     environment:
       DATALAKE: !ImportValue ${self:custom.stage}-datalakeName
       STAGE: ${self:custom.stage}

--- a/services/api/fileStorageDistribution/serverless.yml
+++ b/services/api/fileStorageDistribution/serverless.yml
@@ -28,6 +28,8 @@ custom:
       "before:deploy:deploy": python preDeploy.py --region ${self:custom.userPoolRegion} --userpool_id ${self:custom.userPoolId}
   distributionAlias: storage.${ssm:/${self:custom.stage}/routes/domain_name}
   certificate: ${ssm:/${self:custom.stage}/USEA1/sslIdentifier}
+  pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
 
 package:
   individually: true

--- a/services/ingestion/activeDirectory/serverless.yml
+++ b/services/ingestion/activeDirectory/serverless.yml
@@ -28,6 +28,7 @@ custom:
 
   stage: ${opt:stage, self:provider.stage}
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3 # Default in lambda rt

--- a/services/ingestion/activeDirectoryProcess/serverless.yml
+++ b/services/ingestion/activeDirectoryProcess/serverless.yml
@@ -35,6 +35,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/cvPartner/serverless.yml
+++ b/services/ingestion/cvPartner/serverless.yml
@@ -39,6 +39,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/dora/serverless.yml
+++ b/services/ingestion/dora/serverless.yml
@@ -41,6 +41,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/gitHub/serverless.yml
+++ b/services/ingestion/gitHub/serverless.yml
@@ -37,6 +37,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/googleEvent/lib/googleevent/google_event_ingest_lambda.py
+++ b/services/ingestion/googleEvent/lib/googleevent/google_event_ingest_lambda.py
@@ -22,7 +22,8 @@ def ingest(event) -> Data:
         """
         :return: A list containing the all latest for the calendar ids stored in SSM
         """
-        credentials_from_ssm, calendar_ids_from_ssm = SSM(with_decryption=False).get('credentials', 'calendarIds')
+        credentials_from_ssm = SSM(with_decryption=True).get('credentials')
+        calendar_ids_from_ssm = SSM(with_decryption=False).get('calendarIds')
         service = get_calender_service(credentials_from_ssm)
 
         all_events = []
@@ -60,7 +61,6 @@ def ingest(event) -> Data:
         :param credentials_from_ssm:
         :return: A autorized calendar service using credentials from SSM
         """
-
         credsentials_json = json.loads(credentials_from_ssm)
         scope = ["https://www.googleapis.com/auth/calendar.readonly"]
         credentials = ServiceAccountCredentials.from_service_account_info(credsentials_json)

--- a/services/ingestion/googleEvent/serverless.yml
+++ b/services/ingestion/googleEvent/serverless.yml
@@ -34,6 +34,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/googleForms/serverless.yml
+++ b/services/ingestion/googleForms/serverless.yml
@@ -12,11 +12,6 @@ dataplattform:
   glue:
     tableName: google_forms
     accessLevel: 3
-  hooks:
-    - name: 'Invoke ingestor'
-      trigger: postDeploy
-      type: invoke
-      value: ingest
 
 custom:
   editable:
@@ -35,6 +30,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/googleSheets/serverless.yml
+++ b/services/ingestion/googleSheets/serverless.yml
@@ -12,11 +12,6 @@ dataplattform:
   glue:
     tableName: google_sheets
     accessLevel: 3
-  hooks:
-    - name: 'Invoke ingestor'
-      trigger: postDeploy
-      type: invoke
-      value: ingest
 
 custom:
   editable:
@@ -36,6 +31,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/jiraSales/serverless.yml
+++ b/services/ingestion/jiraSales/serverless.yml
@@ -37,6 +37,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/knowitLabs/serverless.yml
+++ b/services/ingestion/knowitLabs/serverless.yml
@@ -33,6 +33,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/kompetanseKartlegging/requirements.txt
+++ b/services/ingestion/kompetanseKartlegging/requirements.txt
@@ -1,1 +1,2 @@
 file:../../../packages/common
+requests==2.23

--- a/services/ingestion/kompetanseKartlegging/serverless.yml
+++ b/services/ingestion/kompetanseKartlegging/serverless.yml
@@ -32,6 +32,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/slack/serverless.yml
+++ b/services/ingestion/slack/serverless.yml
@@ -12,11 +12,6 @@ dataplattform:
   glue:
     tableName: slack
     accessLevel: 2
-  hooks:
-    - name: 'Invoke ingestor'
-      trigger: postDeploy
-      type: invoke
-      value: ingest
 
 custom:
   editable:
@@ -35,6 +30,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/twitter/lib/twitter/twitter_ingest_lambda.py
+++ b/services/ingestion/twitter/lib/twitter/twitter_ingest_lambda.py
@@ -17,8 +17,8 @@ def as_separated_list(entities, value_key, separator=';'):
 
 @handler.ingest()
 def ingest(event) -> Data:
-    consumer_key, consumer_secret, access_token, access_secret = SSM(with_decryption=True).get(
-        'twitter_comsumer_key', 'twitter_comsumer_secret', 'twitter_access_token', 'twitter_access_secret')
+    consumer_key, consumer_secret, access_token, access_secret = SSM(with_decryption=True)\
+        .get('twitter_consumer_key', 'twitter_consumer_secret', 'twitter_access_token', 'twitter_access_secret')
 
     auth = OAuthHandler(consumer_key, consumer_secret)
     auth.set_access_token(access_token, access_secret)

--- a/services/ingestion/twitter/requirements.txt
+++ b/services/ingestion/twitter/requirements.txt
@@ -1,3 +1,4 @@
 file:../../../packages/common
 file:../../../packages/query
 tweepy==3.10.0
+numpy==1.22.0

--- a/services/ingestion/twitter/serverless.yml
+++ b/services/ingestion/twitter/serverless.yml
@@ -11,11 +11,6 @@ dataplattform:
   glue:
     tableName: twitter
     accessLevel: 1
-  hooks:
-    - name: 'Invoke ingestor'
-      trigger: postDeploy
-      type: invoke
-      value: ingest
 
 custom:
   editable:
@@ -33,6 +28,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/twitter/tox.ini
+++ b/services/ingestion/twitter/tox.ini
@@ -13,8 +13,8 @@ env =
     DEFAULT_DATABASE=test
 
 dataplattform-aws-ssm =
-    /dev/testService/twitter_comsumer_key=SecureString:test_consumer_key
-    /dev/testService/twitter_comsumer_secret=SecureString:test_comsumer_secret
+    /dev/testService/twitter_consumer_key=SecureString:test_consumer_key
+    /dev/testService/twitter_consumer_secret=SecureString:test_consumer_secret
     /dev/testService/twitter_access_token=SecureString:test_access_token
     /dev/testService/twitter_access_secret=SecureString:test_access_secret
 

--- a/services/ingestion/ubwCustomerPerResource/serverless.yml
+++ b/services/ingestion/ubwCustomerPerResource/serverless.yml
@@ -42,6 +42,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/ubwFagtime/serverless.yml
+++ b/services/ingestion/ubwFagtime/serverless.yml
@@ -33,6 +33,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/ingestion/yrWeather/serverless.yml
+++ b/services/ingestion/yrWeather/serverless.yml
@@ -32,6 +32,7 @@ custom:
   sqsQueueName: ${self:custom.stage}-${self:service}-sqs.fifo
   sqsQueueDLName: ${self:custom.stage}-${self:service}-sqs-dl.fifo
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/utils/downloadToBucket/serverless.yml
+++ b/services/utils/downloadToBucket/serverless.yml
@@ -14,6 +14,7 @@ custom:
     description: Downloads documents to a public raw storage bucket
   stage: ${opt:stage, self:provider.stage}
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3

--- a/services/utils/slackAlarmForwarder/serverless.yml
+++ b/services/utils/slackAlarmForwarder/serverless.yml
@@ -14,6 +14,7 @@ custom:
     description: Forwards Alarms from the ${self:custom.stage}-CloudwatchAlarms SNS topic to slack
   stage: ${opt:stage, self:provider.stage}
   pythonRequirements:
+    dockerImage: public.ecr.aws/sam/build-python3.9
     dockerizePip: non-linux
     noDeploy:
       - boto3


### PR DESCRIPTION
- Default imaget til serverless-python-requirements bruker Python v 3.6. Jeg har manuelt satt dette imaget til AWS sitt Python 3.9 image (public.ecr.aws/sam/build-python3.9)
- I `packages/common` har man både importert path og satt funksjonsargumenter til å hete path. Jeg har endret navn på argumentene så de ikke overskygger path fra import.
- Formattering av funksjoner
- Oppdatering av SSM navn med skrivefeil