### PR TITLE
Bruk bash i stedet for sh når man kjører deployment.

### DIFF
--- a/packages/cli/dataplattform/cli/commands/deploy.py
+++ b/packages/cli/dataplattform/cli/commands/deploy.py
@@ -233,7 +233,7 @@ def run_process_per_path(
     for path in paths:
         commands = get_cmd_func(path)
         try:
-            retcode = subprocess.call(' && '.join(commands), shell=True)
+            retcode = subprocess.call(' && '.join(commands), shell=True, executable='/bin/bash')
             if retcode != 0:
                 raise Exception(str("\nAn error occurred while running a subprocess at " + path) if len(path) > 0
                                 else "\nAn error occurred while running a subprocess")


### PR DESCRIPTION
Ubuntu setter default executable til å være `sh`. Sett den til å i stedet være `bash`