### PR TITLE
Handle the case of missing claims

### DIFF
--- a/packages/api/dataplattform/api/flask_ext.py
+++ b/packages/api/dataplattform/api/flask_ext.py
@@ -29,7 +29,7 @@ class UserSession(object):
     def boto_session(self):
         claims = self.user_claims
         if claims:
-            group = self.cognito_group(claims['cognito:groups'], claims['iss'])
+            group = self.cognito_group(claims.get('cognito:groups', None), claims.get('iss', None))
             if group:
                 return self.create_boto_session(group['RoleArn'])
         return boto3._get_default_session()


### PR DESCRIPTION
Fant denne i loggen ved forsøk på å hente data når jeg ikke hadde tilgang

```[ERROR]	2022-12-13T12:12:10.378Z	abd05752-78a1-487b-9677-88e2ba91eac8	Exception on /data/query/report/employeeMotivationAndCompetence [GET]
Traceback (most recent call last):
  File "/var/task/flask/app.py", line 1948, in full_dispatch_request
    rv = self.preprocess_request()
  File "/var/task/flask/app.py", line 2242, in preprocess_request
    rv = func()
  File "/var/task/dataplattform/api/flask_ext.py", line 21, in assume_role
    boto3.DEFAULT_SESSION = self.boto_session
  File "/var/task/dataplattform/api/flask_ext.py", line 32, in boto_session
    group = self.cognito_group(claims['cognito:groups'], claims['iss'])
KeyError: 'cognito:groups'```