### PR TITLE
Fix ubwCustomerPerResource bug

### DIFF
--- a/packages/cli/setup.py
+++ b/packages/cli/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 setup(
     name='dataplattform_cli',
     packages=find_namespace_packages(include=['dataplattform.*']),
-    install_requires=['boto3==1.18.55', 'moto==1.3.14', 'requests==2.23',
+    install_requires=['boto3==1.18.55', 'moto==1.3.14', 'requests<=2.28.0',
                       'python-dateutil==2.8.2', 'pandas==1.3.4', 'fastparquet==0.7.1'],
     dependency_links=['file:../common', 'file:../query', 'file:../testing'],
     entry_points={

--- a/services/ingestion/ubwCustomerPerResource/lib/ubwcustomerperresource/ubw_customer_per_resource_process_lambda.py
+++ b/services/ingestion/ubwCustomerPerResource/lib/ubwcustomerperresource/ubw_customer_per_resource_process_lambda.py
@@ -114,10 +114,6 @@ def process(data, events) -> Dict[str, pd.DataFrame]:
         updated_reg_periods = updated_reg_periods.astype(
             'int').sort_values(ascending=False).astype('str')
 
-        # replace date with correct date. ex 202301 becomes 20231
-        for index, value in reg_periods.items():
-            updated_reg_periods.loc[index] = value
-
         reg_periods = updated_reg_periods.head(num_weeks)
 
         old_frame = old_frame[old_frame['reg_period'].isin(reg_periods)]

--- a/services/ingestion/ubwCustomerPerResource/requirements.txt
+++ b/services/ingestion/ubwCustomerPerResource/requirements.txt
@@ -1,4 +1,4 @@
 file:../../../packages/common
 zeep==3.4
 xmltodict==0.12
-numpy==1.21.2
+numpy==1.22.0

--- a/services/ingestion/ubwCustomerPerResource/tests/test_ubw_customer_per_resource_process_lambda.py
+++ b/services/ingestion/ubwCustomerPerResource/tests/test_ubw_customer_per_resource_process_lambda.py
@@ -31,7 +31,11 @@ def create_date_string(num_weeks_back):
     date = datetime.now()
     delta = timedelta(weeks=num_weeks_back)
     tmp_year, tmp_week = (date - delta).isocalendar()[0:2]
-    return str(tmp_year) + str(tmp_week)
+    tmp_year = str(tmp_year)
+    tmp_week = str(tmp_week)
+    if len(tmp_week) == 1:
+        tmp_week = "0"+tmp_week
+    return tmp_year + tmp_week
 
 
 @fixture


### PR DESCRIPTION
The processor would incorrectly sort dates after new year since since single char weeks would only be 1 instead of 01 leading to 202252 being later than 20231