### PR TITLE
Move AD API url to AWS parameter store

### DIFF
--- a/services/ingestion/activeDirectory/lib/activeDirectory/active_directory_ingest_lambda.py
+++ b/services/ingestion/activeDirectory/lib/activeDirectory/active_directory_ingest_lambda.py
@@ -4,11 +4,11 @@ import boto3
 from os import environ
 import json
 import hashlib
-
-url = 'http://10.205.0.5:20201/api/Users'
+from dataplattform.common.aws import SSM
 
 
 def handler(event, context):
+    url = SSM(with_decryption=False).get('active_directory_url')
     res = requests.get(f'{url}')
     data_json = res.json()
 
@@ -52,8 +52,10 @@ def handler(event, context):
         'managerDistinguishedName': 'manager'}, inplace=True)
     employee_df = employee_df.fillna("")
 
-    employee_df['manager'] = employee_df['manager'].str.split('=').str[1].str.split(',').str[0]
-    employee_df['distinguished_name'] = employee_df['distinguished_name'].str.split('=').str[1].str.split(',').str[0]
+    employee_df['manager'] = employee_df['manager'].str.split(
+        '=').str[1].str.split(',').str[0]
+    employee_df['distinguished_name'] = employee_df['distinguished_name'].str.split(
+        '=').str[1].str.split(',').str[0]
 
     for i in employee_df.columns:
         employee_df[i] = employee_df[i].astype(str)

--- a/services/ingestion/activeDirectory/lib/activeDirectory/active_directory_ingest_lambda.py
+++ b/services/ingestion/activeDirectory/lib/activeDirectory/active_directory_ingest_lambda.py
@@ -8,7 +8,7 @@ from dataplattform.common.aws import SSM
 
 
 def handler(event, context):
-    url = SSM(with_decryption=False).get('active_directory_url')
+    url = SSM(with_decryption=False).get('API_URL')
     res = requests.get(f'{url}')
     data_json = res.json()
 

--- a/services/ingestion/activeDirectory/tests/test_active_directory_ingest_lambda.py
+++ b/services/ingestion/activeDirectory/tests/test_active_directory_ingest_lambda.py
@@ -29,7 +29,8 @@ def add_ddb_dummy_data(ddb_table):
 
 
 def test_initial_ingest(s3_bucket, test_data, dynamodb_resource):
-    responses.add(responses.GET, 'http://10.205.0.5:20201/api/Users', json=make_test_json(test_data), status=200)
+    responses.add(responses.GET, 'http://test.no/api/Users',
+                  json=make_test_json(test_data), status=200)
     resource = boto3.resource('dynamodb')
     table = resource.Table(environ.get('PERSON_DATA_TABLE'))
 
@@ -49,7 +50,8 @@ def test_initial_ingest(s3_bucket, test_data, dynamodb_resource):
 
 def test_filter_service_user(s3_bucket, test_data, dynamodb_resource):
     test_data[2]['isServiceUser'] = True
-    responses.add(responses.GET, 'http://10.205.0.5:20201/api/Users', json=make_test_json(test_data), status=200)
+    responses.add(responses.GET, 'http://test.no/api/Users',
+                  json=make_test_json(test_data), status=200)
 
     handler(None, None)
 

--- a/services/ingestion/activeDirectory/tox.ini
+++ b/services/ingestion/activeDirectory/tox.ini
@@ -12,6 +12,8 @@ env =
     SERVICE=testService
     DEFAULT_DATABASE=test
 
+dataplattform-aws-ssm =
+    /dev/testService/active_directory_url=String:http://test.no/api/Users 
 [testenv]
 usedevelop = true
 deps =

--- a/services/ingestion/activeDirectory/tox.ini
+++ b/services/ingestion/activeDirectory/tox.ini
@@ -13,7 +13,7 @@ env =
     DEFAULT_DATABASE=test
 
 dataplattform-aws-ssm =
-    /dev/testService/active_directory_url=String:http://test.no/api/Users 
+    /dev/testService/API_URL=String:http://test.no/api/Users 
 [testenv]
 usedevelop = true
 deps =


### PR DESCRIPTION
issue: https://github.com/knowit/Dataplattform/issues/516

- Flytt hardkodet Active directory api url til parameter store
- Fikset tester slik at det brukes url fra testkonfig 