### PR TITLE
Update timeout for kompetansekartlegging lambdas

### DIFF
--- a/services/ingestion/kompetanseKartlegging/serverless.yml
+++ b/services/ingestion/kompetanseKartlegging/serverless.yml
@@ -18,7 +18,7 @@ dataplattform:
 
 custom:
   editable:
-    timeout: 200
+    timeout: 420
     srcDir: lib/kompetansekartlegging
     ingestHandlerFile: kompetansekartlegging_ingest_lambda
     processHandlerFile: kompetansekartlegging_process_lambda


### PR DESCRIPTION
Process lambda fikk timeout. Har sjekket manuelt at den kjører i prod med økt timeout. Har deretter lagt inn endring her så det blir økt timeout også ved deploy. 

Faktisk kjøretid var ganske lang, godt over 4 minutter, lurer på hvorfor det tar såpass lang tid...
Duration: 414783.11 ms
Init Duration: 3295.38 ms